### PR TITLE
Use zoom rather than cqi font sizes for scaling slide contents to fit.

### DIFF
--- a/lyricweb/src/slide.rs
+++ b/lyricweb/src/slide.rs
@@ -28,22 +28,22 @@ pub fn Slide(#[prop(into)] slide: Signal<SlideContent>) -> impl IntoView {
                 "font-family: " {theme.font_family} ";"
             "}"
             ".slide h1 {"
-                "font-size:" {theme.heading_size as f32 / 10.0}"cqi;"
+                "font-size:" {theme.heading_size as f32}"pt;"
                 "color: " {theme.heading_colour} ";"
             "}"
             ".slide h2 {"
-                "font-size:" {theme.body_size as f32 / 10.0}"cqi;"
+                "font-size:" {theme.body_size as f32}"pt;"
                 "color: " {theme.body_colour.clone()} ";"
             "}"
             ".slide p {"
-                "font-size:" {theme.body_size as f32 / 10.0}"cqi;"
+                "font-size:" {theme.body_size as f32}"pt;"
                 "color: " {theme.body_colour} ";"
             "}"
             ".slide p.credit {"
-                "font-size:" {theme.body_size as f32 / 20.0} "cqi;"
+                "font-size:" {theme.body_size as f32 / 2.0} "pt;"
             "}"
             </Style>
-            <div class="slide">
+            <div class="slide-container"><div class="slide">
             { content.title.as_ref().map(|title| {
                 view! {
                     <h1>{title.clone()}</h1>
@@ -59,7 +59,7 @@ pub fn Slide(#[prop(into)] slide: Signal<SlideContent>) -> impl IntoView {
                     <p class="credit">{credit.clone()}</p>
                 }
             })}
-            </div>
+            </div></div>
         }
     }
 }

--- a/lyricweb/style.css
+++ b/lyricweb/style.css
@@ -86,7 +86,7 @@ select[size] {
   border: 1px solid red;
 }
 
-.slide {
+.slide-container {
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -96,12 +96,16 @@ select[size] {
   container-type: size;
 }
 
+.slide {
+  zoom: calc(100cqi / 1920px);
+}
+
 .slide p,
 .slide h1,
 .slide h2 {
-  margin-left: 3cqi;
-  margin-right: 1cqi;
-  margin-top: 2cqi;
+  margin-left: 45pt;
+  margin-right: 15pt;
+  margin-top: 30pt;
 }
 
 .slide h1,


### PR DESCRIPTION
This seems to give a more consistent result across slide sizes, in particular for the preview.